### PR TITLE
クイズ投稿バリテーション設置

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -6,12 +6,11 @@ class QuizzesController < ApplicationController
   
   def new
     @quiz = Quiz.new
-    4.times{ @quiz.choices.build }
+    4.times {@quiz.choices.build}
   end
 
   def create
-    binding.pry
-  @quiz = Quiz.new(quiz_params)
+    @quiz = Quiz.new(quiz_params)
     if @quiz.save
     redirect_to root_path
     else
@@ -23,7 +22,17 @@ class QuizzesController < ApplicationController
   private
 
   def quiz_params
-    params.require(:quiz).permit(:quiz,choices_attributes:[:choice, :answer_is]).merge(user_id: current_user.id)
+    quiz = params.require(:quiz).permit(:quiz,choices_attributes:[:choice]).merge(user_id: current_user.id)
+    answer_c = quiz.permit(choices_attributes:[:choice])
+    answer_c[:choices_attributes].each_key do |n|
+      if n == params.require(:select_anwser)
+        quiz[:choices_attributes]["#{n}"].merge!(answer_is: true)
+      else
+        quiz[:choices_attributes]["#{n}"].merge!(answer_is: false)
+      end
+    end
+
+    return quiz
   end
 
 end

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -6,15 +6,17 @@ class QuizzesController < ApplicationController
   
   def new
     @quiz = Quiz.new
-    @quiz.choices.build
-    # 4.times{@quiz.choices.build}
+    4.times{ @quiz.choices.build }
   end
 
   def create
+    binding.pry
   @quiz = Quiz.new(quiz_params)
-  @quiz.save
-  redirect_to root_path
-
+    if @quiz.save
+    redirect_to root_path
+    else
+    render :new
+    end
     
   end
 

--- a/app/models/choice.rb
+++ b/app/models/choice.rb
@@ -1,5 +1,8 @@
 class Choice < ApplicationRecord
 
   belongs_to :quiz
+
+  validates :choice, presence: true
+  validates :anwser_is, acceptance: true
   
 end

--- a/app/models/choice.rb
+++ b/app/models/choice.rb
@@ -3,6 +3,5 @@ class Choice < ApplicationRecord
   belongs_to :quiz
 
   validates :choice, presence: true
-  validates :anwser_is, acceptance: true
   
 end

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -4,4 +4,11 @@ class Quiz < ApplicationRecord
   has_many :choices
   accepts_nested_attributes_for :choices
 
+  validates_associated :choices
+
+  
+  validates :quiz, presence: true
+  
+
+
 end

--- a/app/views/quizzes/new.html.erb
+++ b/app/views/quizzes/new.html.erb
@@ -1,12 +1,10 @@
 <%= form_for(@quiz) do |f| %>
-  <h2> 問題文　</h2>
+  <h2> 問題文 </h2>
   <div>
     <%= f.text_area :quiz, size: "50x3", placeholder:"問題文を入力してください。" %>
   </div>
 
     <h2>選択肢</h2>
-    <h4>答えにする選択肢を一つだけ選んでチェックをつけてください。</h4>
-    <%# <% 4.times do |x| %>
       <% x = 1 %>
       <%= f.fields_for :choices do |c| %>
         <div>
@@ -16,12 +14,15 @@
         <div>
           <%= c.text_field :choice, size: "40x1" %>
         </div>
-        <div>
-        正解ならクリック
-        <%= c.check_box :answer_is, {}, "true", "false" %>
-        </div>
         <br>
       <% end %>
+      <h4>答えにする選択肢を一つだけ選んでチェックをつけてください。</h4>
+
+      <label><%= radio_button_tag :select_anwser, "0", checked: true %>選択肢1</label><br>
+      <label><%= radio_button_tag :select_anwser, "1" %>選択肢2</label><br>
+      <label><%= radio_button_tag :select_anwser, "2" %>選択肢3</label><br>
+      <label><%= radio_button_tag :select_anwser, "3" %>選択肢4</label>
+
       <div>
         <%= f.submit "問題登録" %>
       </div>

--- a/app/views/quizzes/new.html.erb
+++ b/app/views/quizzes/new.html.erb
@@ -1,19 +1,30 @@
 <%= form_for(@quiz) do |f| %>
   <h2> 問題文　</h2>
   <div>
-    <%= f.text_area :quiz, size: "50x7", placeholder:"問題文を入力してください。" %>
-  </div><br>
+    <%= f.text_area :quiz, size: "50x3", placeholder:"問題文を入力してください。" %>
+  </div>
 
     <h2>選択肢</h2>
     <h4>答えにする選択肢を一つだけ選んでチェックをつけてください。</h4>
-    <% 4.times do |x| %>
+    <%# <% 4.times do |x| %>
+      <% x = 1 %>
       <%= f.fields_for :choices do |c| %>
-      <%= "選択肢#{x+1}"%>
-      <%= c.text_field :choice, size: "40x1" %>
-      <%= c.check_box :answer_is, {}, "true", "false" %><div>
-    <% end %>
-  <% end %>
-  <%= f.submit "問題登録" %>
+        <div>
+          <%= "選択肢#{x}"%>
+          <% x += 1%>
+        </div>
+        <div>
+          <%= c.text_field :choice, size: "40x1" %>
+        </div>
+        <div>
+        正解ならクリック
+        <%= c.check_box :answer_is, {}, "true", "false" %>
+        </div>
+        <br>
+      <% end %>
+      <div>
+        <%= f.submit "問題登録" %>
+      </div>
 <% end %>
 <br><br>
 <%= link_to "トップ画面に戻る", root_path %>


### PR DESCRIPTION
問題の正解選択をチェックボックスからラジオボタンに変更

それに伴い、クイズ投稿画面のレイアウトを変更

問題文及び、選択肢の全てに文字が入っていないとバリテーション が作動するようにした